### PR TITLE
Add basic LoginPage test

### DIFF
--- a/frontend/src/__tests__/LoginPage.test.js
+++ b/frontend/src/__tests__/LoginPage.test.js
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import LoginPage from '../pages/LoginPage'
+
+// Mock AuthContext to avoid network requests and provide minimal functions
+jest.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    login: jest.fn(),
+  }),
+}))
+
+describe('LoginPage', () => {
+  test('renders email and password inputs and submit button', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Parolă/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Autentificare/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add a test for LoginPage under `src/__tests__`
- render LoginPage inside a router and check for email, password and submit button

## Testing
- `npm test --silent -- -w 1` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544ec7614c83299daa46dd758be3f4